### PR TITLE
Compact and Flatten Positional Params

### DIFF
--- a/addon/components/fit-form/component.js
+++ b/addon/components/fit-form/component.js
@@ -1,13 +1,18 @@
 import Component from '@ember/component';
 import layout from './template';
 
-import { A as emberArray, makeArray } from '@ember/array';
+import { A, makeArray } from '@ember/array';
 import { computed } from '@ember/object';
 import { inject } from '@ember/service';
 
 /**
  * Wraps a native `<form>` element and provides abstractions for working with models and model validations.
  */
+function flat(arr) { return [].concat(...arr) }
+function compact(arr) { return arr.filter(v => v != null) }
+function flattenAndCompact(o) {
+  return A(compact(flat(makeArray(o))));
+}
 
 const FitFormComponent = Component.extend({
   fitFormService: inject('fit-form'),
@@ -63,7 +68,7 @@ const FitFormComponent = Component.extend({
 
   formObject: computed('models.[]', 'adapter', function() {
     const Adapter = this.get('fitFormService').lookupAdapter(this.get('adapter'));
-    const emberModelArray = emberArray(makeArray(this.get('models')));
+    const modelArray = flattenAndCompact(this.get('models'));
 
     const hooks = [
       'oncancel', 'onerror', 'oninvalid', 'onsubmit', 'onsuccess', 'onvalidate'
@@ -74,7 +79,7 @@ const FitFormComponent = Component.extend({
     }, {});
 
     const adapter = Adapter.create({
-      models: emberModelArray,
+      models: modelArray,
       ...hooks
     });
 

--- a/tests/integration/components/fit-form/component-test.js
+++ b/tests/integration/components/fit-form/component-test.js
@@ -24,6 +24,58 @@ module('Integration | Component | fit-form', function(hooks) {
     assert.dom('form').hasText('template block text');
   });
 
+  test('a form with models', async function(assert) {
+    assert.expect(5);
+
+    const changeset = new Changeset({});
+
+    this.setProperties({
+      changeset,
+      changesets: [ changeset, changeset ]
+    });
+
+    await render(hbs`
+    {{#fit-form undefined as |form|}}
+      {{#each form.models as |m i|}}
+        index-{{i}}
+      {{/each}}
+    {{/fit-form}}
+  `);
+
+    assert.dom('form').doesNotIncludeText('index-0', 'renders no models with an undefined param');
+
+    await render(hbs`
+    {{#fit-form changeset as |form|}}
+      {{#each form.models as |m i|}}
+        index-{{i}}
+      {{/each}}
+    {{/fit-form}}
+  `);
+
+    assert.dom('form').includesText('index-0', 'accepts an object as a param');
+    assert.dom('form').doesNotIncludeText('index-1');
+
+    await render(hbs`
+    {{#fit-form changeset changeset as |form|}}
+      {{#each form.models as |m i|}}
+        index-{{i}}
+      {{/each}}
+    {{/fit-form}}
+  `);
+
+    assert.dom('form').includesText('index-1', 'accepts many objects as params');
+
+    await render(hbs`
+    {{#fit-form changesets as |form|}}
+      {{#each form.models as |m i|}}
+        index-{{i}}
+      {{/each}}
+    {{/fit-form}}
+  `);
+
+    assert.dom('form').includesText('index-1', 'accepts an array as a param');
+  });
+
   test('Submitting a form', async function(assert) {
     assert.expect(6);
 


### PR DESCRIPTION
## Purpose
Some use-cases were reported that a parent component was passing in `undefined` and an array of objects as the positional parameters for ember-fit-form. 

An `undefined` values caused `models === [ undefined ]`
An array of objects, ie ` [ Object ]`, value caused `models === [ [ Object ] ]`

## Approach
Compact the `models` to resolve `[ undefined ]` positional parameters
Flatten the `models` to resolve `[ [ Object ]  ]` positional parameters