### PR TITLE
Update to Ember 3.12

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
     sourceType: 'module'
   },
   plugins: [
@@ -36,8 +36,7 @@ module.exports = {
         'tests/dummy/app/**'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /node_modules/
 
 # misc
+/.env*
+/.pnp*
 /.sass-cache
 /connect.lock
 /coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,7 @@
 /.bowerrc
 /.editorconfig
 /.ember-cli
+/.env*
 /.eslintignore
 /.eslintrc.js
 /.gitignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty
@@ -18,6 +18,12 @@ env:
   global:
     # See https://git.io/vdao3 for details.
     - JOBS=1
+
+branches:
+  only:
+    - master
+    # npm version tags
+    - /^v\d+\.\d+\.\d+/
 
 jobs:
   fail_fast: true
@@ -38,9 +44,8 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
+      env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.8
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ support promise-aware hooks to manage your applications form state.
 
 > Please note that `ember-fit-form` does not provide form control components. It is simply an html form element with abstractions for state management.
 
+
+Compatibility
+------------------------------------------------------------------------------
+
+* Ember.js v2.18 or above
+* Ember CLI v2.13 or above
+* Node.js v8 or above
+
+
 Installation
 ------------------------------------------------------------------------------
 
@@ -590,6 +599,11 @@ In this example, we'll extend the `ember-changeset` form-adapter. We will overwr
     {{!-- other form content --}}
   {{/fit-form}}
   ```
+
+License
+------------------------------------------------------------------------------
+
+This project is licensed under the [MIT License](LICENSE.md).
 
 [build-status-img]: https://travis-ci.org/truecoach/ember-fit-form.svg?branch=master
 [build-status-link]: https://travis-ci.org/truecoach/ember-fit-form

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,102 +2,91 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-module.exports = function() {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary')
-  ]).then((urls) => {
-    return {
-      useYarn: true,
-      scenarios: [
-        {
-          name: 'ember-lts-2.16',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.16.0',
-              'ember-data': '~2.16.0'
-            }
-          }
+module.exports = async function() {
+  return {
+    useYarn: true,
+    scenarios: [
+      {
+        name: 'ember-lts-2.18',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
         },
-        {
-          name: 'ember-lts-2.18',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0',
-              'ember-data': '~2.18.0'
-            }
-          }
-        },
-        {
-          name: 'ember-lts-3.4',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.4.0',
-              'ember-data': '~3.4.0'
-            }
-          }
-        },
-        {
-          name: 'ember-release',
-          npm: {
-            devDependencies: {
-              'ember-source': urls[0],
-              'ember-data': 'emberjs/data#release'
-            }
-          }
-        },
-        {
-          name: 'ember-beta',
-          npm: {
-            devDependencies: {
-              'ember-source': urls[1],
-              'ember-data': 'emberjs/data#beta'
-            }
-          }
-        },
-        {
-          name: 'ember-canary',
-          npm: {
-            devDependencies: {
-              'ember-source': urls[2],
-              'ember': 'components/ember#canary'
-            }
-          }
-        },
-        // The default `.travis.yml` runs this scenario via `npm test`,
-        // not via `ember try`. It's still included here so that running
-        // `ember try:each` manually or from a customized CI config will run it
-        // along with all the other scenarios.
-        {
-          name: 'ember-default',
-          npm: {
-            'ember-data': 'emberjs/data#master'
-          }
-        },
-        {
-          name: 'ember-default-with-jquery',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': true
-            })
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-data': 'emberjs/data#master'
-            }
+        npm: {
+          devDependencies: {
+            '@ember/jquery': '^0.5.1',
+            'ember-source': '~2.18.0',
+            'ember-data': '~2.18.0'
           }
         }
-      ]
-    };
-  });
+      },
+      {
+        name: 'ember-lts-3.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.4.0',
+            'ember-data': '~3.4.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.8.0',
+            'ember-data': '~3.8.0'
+          }
+        }
+      },
+      {
+        name: 'ember-release',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('release'),
+            'ember-data': 'latest',
+          }
+        }
+      },
+      {
+        name: 'ember-beta',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('beta'),
+            'ember-data': 'beta',
+          }
+        }
+      },
+      {
+        name: 'ember-canary',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('canary'),
+            'ember-data': 'canary',
+          }
+        }
+      },
+      // The default `.travis.yml` runs this scenario via `npm test`,
+      // not via `ember try`. It's still included here so that running
+      // `ember try:each` manually or from a customized CI config will run it
+      // along with all the other scenarios.
+      {
+        name: 'ember-default',
+        npm: {
+          devDependencies: {}
+        }
+      },
+      {
+        name: 'ember-default-with-jquery',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({
+            'jquery-integration': true
+          })
+        },
+        npm: {
+          devDependencies: {
+            '@ember/jquery': '^0.5.1',
+          }
+        }
+      }
+    ]
+  };
 };

--- a/package.json
+++ b/package.json
@@ -23,18 +23,18 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.1.2",
-    "ember-cli-htmlbars": "^3.0.0",
+    "ember-cli-babel": "^7.7.3",
+    "ember-cli-htmlbars": "^3.0.1",
     "ember-concurrency": "^0.8.0"
   },
   "devDependencies": {
-    "@ember/optional-features": "^0.6.3",
-    "broccoli-asset-rev": "^2.7.0",
+    "@ember/optional-features": "^0.7.0",
+    "broccoli-asset-rev": "^3.0.0",
     "ember-changeset-validations": "^1.2.11",
-    "ember-cli": "~3.6.1",
-    "ember-cli-dependency-checker": "^3.0.0",
-    "ember-cli-eslint": "^4.2.3",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.3",
+    "ember-cli": "~3.12.0",
+    "ember-cli-dependency-checker": "^3.1.0",
+    "ember-cli-eslint": "^5.1.0",
+    "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",
@@ -42,21 +42,21 @@
     "ember-data": "~3.6.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
-    "ember-load-initializers": "^1.1.0",
+    "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^3.4.1",
+    "ember-qunit": "^4.4.1",
     "ember-resolver": "^5.0.1",
     "ember-sinon": "^3.1.0",
-    "ember-source": "~3.6.0",
+    "ember-source": "~3.12.0",
     "ember-source-channel-url": "^1.1.0",
     "ember-try": "^1.0.0",
-    "eslint-plugin-ember": "^5.2.0",
-    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-ember": "^6.2.0",
+    "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
-    "qunit-dom": "^0.8.0"
+    "qunit-dom": "^0.8.4"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^3.0.1",
-    "ember-concurrency": "^0.8.0"
+    "ember-concurrency": "^1.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/testem.js
+++ b/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -9,7 +9,7 @@ module.exports = function(environment) {
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
-        // e.g. 'with-controller': true
+        // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.


### PR DESCRIPTION
## Purpose
Upgrade to Ember 3.12

## Approach
- `ember-cli-update --to 3.12`
- bump `ember-concurrency@^1.0.0` for Ember 3.9 compatability

Copied ember-data devDependencies scenarios from [ember-local-storage/config/ember-try.js](https://github.com/funkensturm/ember-local-storage/blob/master/config/ember-try.js)