### PR TITLE
[chore] bump minimum node_js version in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
 sudo: false
 dist: trusty


### PR DESCRIPTION
## Purpose
Latest dependabot builds are failing

## Approach
Bump node version for travis ci