### PR TITLE
[bugfix] Add splattributes to form element

### DIFF
--- a/addon/components/fit-form.hbs
+++ b/addon/components/fit-form.hbs
@@ -1,4 +1,5 @@
 <form
+  ...attributes
   {{on "submit" this.handleSubmit}}
   {{on "keydown" this.handleKeydown}}
   {{on "keyup" this.handleKeyup}}

--- a/tests/integration/components/fit-form/component-test.js
+++ b/tests/integration/components/fit-form/component-test.js
@@ -24,6 +24,25 @@ module('Integration | Component | fit-form', function (hooks) {
     assert.dom('form').hasText('template block text');
   });
 
+  test('Adding attributes to the form', async function (assert) {
+    await render(hbs`
+    <FitForm class="test_class" data-test="test selector">
+      template block text
+    </FitForm>
+    `);
+
+    assert
+      .dom('form')
+      .hasClass('test_class', 'form is rendered with the class');
+    assert
+      .dom('form')
+      .hasAttribute(
+        'data-test',
+        'test selector',
+        'form is rendered with the test selector'
+      );
+  });
+
   test('a form with models', async function (assert) {
     assert.expect(4);
 


### PR DESCRIPTION
## Purpose
3.0.0 broke the ability to apply classes and other attributes directly to the form element

## Approach
- Adds `...attributes` to the form element rendered by the FitForm component
- Adds a regression test
